### PR TITLE
Delete plot test after testing

### DIFF
--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,0 +1,11 @@
+# This runs ONCE after all tests are completed
+
+plot_dir <- testthat::test_path("data", "intermediate_plots")
+
+leftover_files <- fs::dir_ls(plot_dir, fail = FALSE, type = "file")
+# file data/intermediate_plots/plot_examples_features_dist_page1.png
+# is not deleted during the test phase, I cannot find the reason why.
+# Forcing its deletion here, I'll remove following if I do.
+if (length(leftover_files) > 0) {
+  fs::file_delete(leftover_files)
+}

--- a/tests/testthat/test_plot_data.R
+++ b/tests/testthat/test_plot_data.R
@@ -240,7 +240,6 @@ testthat::test_that("plot_data_features saves PNG files", {
   base::unlink(tmp_log)
 })
 
-
 testthat::test_that("plot_data_features handles multiple chart types", {
   dt <- create_test_data()
   temp_file <- tempfile(fileext = ".csv")
@@ -275,6 +274,8 @@ testthat::test_that("plot_data_features warns on unknown chart type", {
     )
   )
   testthat::expect_length(result, 0)
+  # Cleanup
+  unlink(result)
 })
 
 testthat::test_that("plot_data_features respects column selection", {
@@ -322,7 +323,7 @@ testthat::test_that("plot_data_features creates multi-page output", {
   testthat::expect_true(any(grepl("page3", paths)))
 
   # Cleanup
-  unlink(paths)
+  unlink(paths, recursive = TRUE)
 })
 
 # Test: .default_opts


### PR DESCRIPTION
Plot file created but not deleted after testing. This behaviour is unexpected, implementing method to delete it.
@acidroyo 