### PR TITLE
bug in save_data with plots with missing name 

### DIFF
--- a/R/save_data.R
+++ b/R/save_data.R
@@ -97,7 +97,8 @@ save_data <- function(
       {
         picard::plot_data_features(
           data = data_to_plot,
-          file_path = file_path,
+          file_name = tools::file_path_sans_ext(basename(file_path)),
+          plot_path = plot_path,
           ...
         )
       },
@@ -120,9 +121,12 @@ save_data <- function(
 #' @return Named list with normalized_path
 #' @keywords internal
 prepare_output_path <- function(
-    file_path,
-    file_name = NULL,
-    create_dir = TRUE) {
+  file_path,
+  file_name = NULL,
+  create_dir = TRUE
+) {
+
+  ## STEP 1. Check if everything is good with file_path
   # Trim whitespace
   file_path <- trimws(file_path)
 
@@ -146,7 +150,7 @@ prepare_output_path <- function(
   # Normalize path
   file_path <- fs::path_norm(file_path)
 
-  # Handle optional file_name parameter
+  ## STEP 2. Check if everything is good with optional file_name parameter
   if (!is.null(file_name)) {
     if (!is.character(file_name)) {
       stop(
@@ -169,13 +173,44 @@ prepare_output_path <- function(
     if (nzchar(file_name) == 0) {
       stop("file_name cannot be an empty string", call. = FALSE)
     }
-
-    file_path <- file.path(file_path, file_name)
   }
 
-  # Extract directory
-  out_dir <- dirname(file_path)
+  # Step 3. Create a final file_path to be used
+  path_dir  <- base::dirname(file_path)
+  path_base <- base::basename(file_path)
+  path_has_file <- nzchar(tools::file_ext(path_base))
 
+  if (!path_has_file) {
+    # file_path is a directory — file_name is required
+    if (is.null(file_name)) {
+      stop(
+        "file_path contains no filename and file_name is NULL. ",
+        "Please supply a filename via file_name.",
+        call. = FALSE
+      )
+    }
+    file_path <- fs::path(file_path, file_name)
+
+  } else {
+    # file_path already carries a filename
+    if (!is.null(file_name)) {
+      name_ext <- tools::file_ext(file_name)
+
+      if (nzchar(name_ext)) {
+        # file_name has an extension — full replacement
+        file_path <- fs::path(path_dir, file_name)
+      } else {
+        # file_name has no extension — replace stem, keep original extension
+        original_ext <- tools::file_ext(path_base)
+        file_path <- fs::path(path_dir, paste0(file_name, ".", original_ext))
+      }
+    }
+    # if file_name is NULL, file_path stays as-is
+  }
+
+  # STEP 4. Ensure directory exists and is writable
+  # Extract directory
+  out_dir <- base::dirname(file_path)
   # Create directory if needed
   if (!dir.exists(out_dir)) {
     if (create_dir) {

--- a/R/save_data.R
+++ b/R/save_data.R
@@ -35,16 +35,8 @@ save_data <- function(
   path_info <- prepare_output_path(file_path, file_name)
   file_path <- path_info$normalized_path
 
-  # Extract extension
+  # Extract extension # It cannot fails cause tested in prepare_output_path
   ext <- tools::file_ext(file_path)
-  if (ext == "") {
-    stop(
-      "File has no extension or extension could not be detected: ",
-      file_path,
-      "\nSupported extensions: ", paste(list_writers(), collapse = ", "),
-      call. = FALSE
-    )
-  }
 
   # Normalize extension (lowercase)
   ext <- tolower(ext)
@@ -93,20 +85,11 @@ save_data <- function(
       }
     }
 
-    tryCatch(
-      {
-        picard::plot_data_features(
-          data = data_to_plot,
-          file_name = tools::file_path_sans_ext(basename(file_path)),
-          plot_path = plot_path,
-          ...
-        )
-      },
-      error = function(e) {
-        logger::log_warn(paste0(
-          "Failed to create plots: ", e$message
-        ))
-      }
+    picard::plot_data_features(
+      data = data_to_plot,
+      file_name = tools::file_path_sans_ext(basename(file_path)),
+      plot_path = plot_path,
+      ...
     )
   }
 
@@ -127,13 +110,13 @@ prepare_output_path <- function(
 ) {
 
   ## STEP 1. Check if everything is good with file_path
-  # Trim whitespace
-  file_path <- trimws(file_path)
-
   # Validate file_path
   if (is.null(file_path)) {
     stop("file_path cannot be NULL", call. = FALSE)
   }
+
+  # Trim whitespace
+  file_path <- trimws(file_path)
 
   if (length(file_path) != 1) {
     stop(

--- a/tests/testthat/test_save_data.R
+++ b/tests/testthat/test_save_data.R
@@ -15,8 +15,7 @@ testthat::test_that("save_data errors when file has no extension", {
 
   testthat::expect_error(
     save_data(data.frame(a = 1), file_path = path),
-    "file_path contains no filename and file_name is NULL. Please supply a filename via file_name.",
-    fixed = TRUE
+    regexp = "file_path contains no filename and file_name is NULL.",
   )
 })
 

--- a/tests/testthat/test_save_data.R
+++ b/tests/testthat/test_save_data.R
@@ -147,10 +147,11 @@ testthat::test_that("create_plot does not error even if plotting fails", {
     save_data(
       dt,
       file_path = path,
-      create_plot = TRUE,
+      create_plot = FALSE,
       exclude_columns_from_plots = c(
         "person_id", "pregnancy_id", "unique_id"
-      )
+      ),
+      file_name = "gigio"
     )
   )
 })

--- a/tests/testthat/test_save_data.R
+++ b/tests/testthat/test_save_data.R
@@ -15,7 +15,7 @@ testthat::test_that("save_data errors when file has no extension", {
 
   testthat::expect_error(
     save_data(data.frame(a = 1), file_path = path),
-    "File has no extension",
+    "file_path contains no filename and file_name is NULL. Please supply a filename via file_name.",
     fixed = TRUE
   )
 })
@@ -147,11 +147,17 @@ testthat::test_that("create_plot does not error even if plotting fails", {
     save_data(
       dt,
       file_path = path,
-      create_plot = FALSE,
+      create_plot = TRUE,
       exclude_columns_from_plots = c(
         "person_id", "pregnancy_id", "unique_id"
       ),
       file_name = "gigio"
+    )
+  )
+
+  testthat::expect_true(
+    base::file.exists(
+      "data/intermediate_plots/gigio_features_dist_page1.png"
     )
   )
 })
@@ -164,7 +170,7 @@ testthat::test_that("prepare_output_path validates file_path", {
 
   testthat::expect_error(
     prepare_output_path(NULL),
-    regexp = "file_path must be a single string, not a vector of length"
+    regexp = "file_path cannot be NULL"
   )
 
   testthat::expect_error(


### PR DESCRIPTION
File name needs to be expressed because it is so in plot_data and it doesn't get passed for this reason with "..."