### PR TITLE
Add save as parquet to execute sql file

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, local::. any::dplyr
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::. any::dplyr
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Build site

--- a/.github/workflows/r_cmd_check.yaml
+++ b/.github/workflows/r_cmd_check.yaml
@@ -36,9 +36,13 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - name: Set up R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck any::dplyr
+          extra-packages: |
+            any::testthat
+            any::devtools
+            any::dplyr
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/r_cmd_check.yaml
+++ b/.github/workflows/r_cmd_check.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck any::dplyr
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/r_cmd_check.yaml
+++ b/.github/workflows/r_cmd_check.yaml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,  r: 'release'}
-          - {os: ubuntu-latest,  r: 'oldrel-1'}
+          - { os: macos-latest, r: "release" }
+          - { os: windows-latest, r: "release" }
+          - { os: ubuntu-latest, r: "release" }
+          - { os: ubuntu-latest, r: "oldrel-1" }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -42,7 +42,6 @@ jobs:
           extra-packages: |
             any::testthat
             any::devtools
-            any::dplyr
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::DT any::dplyr
+          extra-packages: any::covr, any::DT
           needs: coverage
 
       - name: Test coverage

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::DT
+          extra-packages: any::covr, any::DT any::dplyr
           needs: coverage
 
       - name: Test coverage

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -45,7 +45,6 @@ jobs:
           extra-packages: |
             any::testthat
             any::devtools
-            any::dplyr
           needs: test
 
       - name: Run tests

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: macos-latest,    r: 'release'}
-          - {os: windows-latest,  r: 'release'}
+          - { os: ubuntu-latest, r: "release" }
+          - { os: macos-latest, r: "release" }
+          - { os: windows-latest, r: "release" }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -45,6 +45,7 @@ jobs:
           extra-packages: |
             any::testthat
             any::devtools
+            any::dplyr
           needs: test
 
       - name: Run tests

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     scriptName (>= 1.0.1),
     stats (>= 3.6.2)
 Suggests:
+    dplyr (>= 1.2.0),
     lintr (>= 3.2.0),
     styler (>= 1.10.3),
     devtools (>= 2.4.6),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     data.table (>= 1.17.8),
     ggplot2 (>= 4.0.0),
     patchwork (>= 1.3.2),
-    processx (>= 3.8.6),
     readxl (>= 1.4.5),
     here (>= 1.0.2),
     arrow (>= 22.0.0),

--- a/R/load_sql_query.R
+++ b/R/load_sql_query.R
@@ -167,6 +167,9 @@ execute_sql_file <- function(
     sql,
     conn,
     execute = TRUE,
+    save_as_parquet = FALSE,
+    parquet_path = NULL,
+    partition_by = NULL,
     ...) {
   if (!execute) {
     return(sql)
@@ -178,7 +181,22 @@ execute_sql_file <- function(
     grepl("^WITH\\b", sql_trimmed)
 
   if (is_select) {
-    DBI::dbGetQuery(conn, sql, ...)
+    result <- DBI::dbGetQuery(conn, sql, ...)
+
+    # If save_as_parquet is TRUE, save the result to a Parquet file
+    if (save_as_parquet) {
+      if (is.null(parquet_path)) {
+        stop("parquet_path must be provided when save_as_parquet is TRUE", call. = FALSE)
+      }
+      arrow::write_dataset(
+        result,
+        path = parquet_path,
+        format = "parquet",
+        partitioning = partition_by
+      )
+    }
+
+    result
   } else {
     DBI::dbExecute(conn, sql, ...)
   }

--- a/R/load_sql_query.R
+++ b/R/load_sql_query.R
@@ -174,8 +174,8 @@ execute_sql_file <- function(
 
   # Determine if this is a SELECT query or modification query
   sql_trimmed <- trimws(toupper(sql))
-  is_select <- grepl("^SELECT", sql_trimmed) ||
-    grepl("^WITH.*SELECT", sql_trimmed)
+  is_select <- grepl("^SELECT\\b", sql_trimmed) ||
+    grepl("^WITH\\b", sql_trimmed)
 
   if (is_select) {
     DBI::dbGetQuery(conn, sql, ...)

--- a/R/load_sql_query.R
+++ b/R/load_sql_query.R
@@ -144,6 +144,10 @@ interpolate_sql_params <- function(sql, params) {
 #' @param conn DBI connection object
 #' @param execute logical; if TRUE (default), execute the query.
 #'   If FALSE, return the interpolated SQL string.
+#' @param save_as_parquet logical; if TRUE, saves the result of a SELECT query
+#' @param parquet_path character; file path to save the Parquet file if `save
+#'  as_parquet` is TRUE. Required if `save_as_parquet` is TRUE.
+#' @param partition_by vector of column names to partition the Parquet file
 #' @param ... additional arguments passed to DBI::dbExecute or DBI::dbGetQuery
 #'
 #' @return If execute = TRUE, returns result from DBI.
@@ -186,7 +190,10 @@ execute_sql_file <- function(
     # If save_as_parquet is TRUE, save the result to a Parquet file
     if (save_as_parquet) {
       if (is.null(parquet_path)) {
-        stop("parquet_path must be provided when save_as_parquet is TRUE", call. = FALSE)
+        stop(
+          "parquet_path must be provided when save_as_parquet is TRUE",
+          call. = FALSE
+        )
       }
       arrow::write_dataset(
         result,

--- a/man/execute_sql_file.Rd
+++ b/man/execute_sql_file.Rd
@@ -4,7 +4,15 @@
 \alias{execute_sql_file}
 \title{Execute SQL file with parameter interpolation}
 \usage{
-execute_sql_file(sql, conn, execute = TRUE, ...)
+execute_sql_file(
+  sql,
+  conn,
+  execute = TRUE,
+  save_as_parquet = FALSE,
+  parquet_path = NULL,
+  partition_by = NULL,
+  ...
+)
 }
 \arguments{
 \item{sql}{A sql query string typically loaded via \code{load_sql_query()}}
@@ -13,6 +21,12 @@ execute_sql_file(sql, conn, execute = TRUE, ...)
 
 \item{execute}{logical; if TRUE (default), execute the query.
 If FALSE, return the interpolated SQL string.}
+
+\item{save_as_parquet}{logical; if TRUE, saves the result of a SELECT query}
+
+\item{parquet_path}{character; file path to save the Parquet file if \verb{save as_parquet} is TRUE. Required if \code{save_as_parquet} is TRUE.}
+
+\item{partition_by}{vector of column names to partition the Parquet file}
 
 \item{...}{additional arguments passed to DBI::dbExecute or DBI::dbGetQuery}
 }

--- a/tests/testthat/test_load_sql_query.R
+++ b/tests/testthat/test_load_sql_query.R
@@ -256,3 +256,98 @@ testthat::test_that("INSERT executes and SELECT returns a data frame", {
   testthat::expect_equal(out$x, 1)
   DBI::dbDisconnect(conn)
 })
+
+testthat::test_that("SELECT query saves result to Parquet file", {
+  conn <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+
+  # Create a table and insert some data
+  DBI::dbExecute(conn, "CREATE TABLE t (x INTEGER, y TEXT)")
+  DBI::dbExecute(conn, "INSERT INTO t (x, y) VALUES (1, 'a'), (2, 'b')")
+
+  # Temporary file or directory for Parquet output
+  parquet_path <- tempfile()
+
+  # Execute the SELECT query and save the result to Parquet
+  execute_sql_file(
+    sql = "SELECT * FROM t",
+    conn = conn,
+    execute = TRUE,
+    save_as_parquet = TRUE,
+    parquet_path = parquet_path
+  )
+
+  # Check if the output is a directory (partitioned) or a single file
+  if (dir.exists(parquet_path)) {
+    # If it's a directory, find the first Parquet file
+    parquet_files <- list.files(
+      parquet_path, recursive = TRUE, full.names = TRUE, pattern = "\\.parquet$"
+    )
+    testthat::expect_true(length(parquet_files) > 0)
+    parquet_data <- arrow::read_parquet(parquet_files[1])
+  } else {
+    # If it's a single file, read it directly
+    testthat::expect_true(file.exists(parquet_path))
+    parquet_data <- arrow::read_parquet(parquet_path)
+  }
+
+  # Verify the contents of the Parquet file
+  testthat::expect_s3_class(parquet_data, "data.frame")
+  testthat::expect_equal(parquet_data$x, c(1, 2))
+  testthat::expect_equal(parquet_data$y, c("a", "b"))
+
+  DBI::dbDisconnect(conn)
+})
+
+testthat::test_that("SELECT query saves result to partitioned Parquet files", {
+  conn <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+
+  # Create a table and insert some data
+  DBI::dbExecute(conn, "CREATE TABLE t (x INTEGER, y TEXT)")
+  DBI::dbExecute(conn, "INSERT INTO t (x, y) VALUES (1, 'a'), (2, 'b')")
+
+  # Temporary directory for partitioned Parquet output
+  parquet_dir <- tempfile()
+
+  # Execute the SELECT query and save the result to partitioned Parquet files
+  execute_sql_file(
+    sql = "SELECT * FROM t",
+    conn = conn,
+    execute = TRUE,
+    save_as_parquet = TRUE,
+    parquet_path = parquet_dir,
+    partition_by = "y"
+  )
+
+  # Check that the partitioned Parquet files were created
+  testthat::expect_true(dir.exists(parquet_dir))
+  partition_files <- list.files(parquet_dir, recursive = TRUE)
+  testthat::expect_true(length(partition_files) > 0)
+
+  # Read one of the partitioned Parquet files and verify its contents
+  partitioned_data <- arrow::read_parquet(file.path(parquet_dir, "y=a/part-0.parquet"))
+  testthat::expect_s3_class(partitioned_data, "data.frame")
+  testthat::expect_equal(partitioned_data$x, 1)
+
+  DBI::dbDisconnect(conn)
+})
+
+testthat::test_that("Error is raised if parquet_path is not provided when save_as_parquet is TRUE", {
+  conn <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+
+  # Create a table and insert some data
+  DBI::dbExecute(conn, "CREATE TABLE t (x INTEGER)")
+  DBI::dbExecute(conn, "INSERT INTO t (x) VALUES (1)")
+
+  # Attempt to save to Parquet without providing parquet_path
+  testthat::expect_error(
+    execute_sql_file(
+      sql = "SELECT * FROM t",
+      conn = conn,
+      execute = TRUE,
+      save_as_parquet = TRUE
+    ),
+    regexp = "parquet_path must be provided when save_as_parquet is TRUE"
+  )
+
+  DBI::dbDisconnect(conn)
+})

--- a/tests/testthat/test_load_sql_query.R
+++ b/tests/testthat/test_load_sql_query.R
@@ -324,14 +324,16 @@ testthat::test_that("SELECT query saves result to partitioned Parquet files", {
   testthat::expect_true(length(partition_files) > 0)
 
   # Read one of the partitioned Parquet files and verify its contents
-  partitioned_data <- arrow::read_parquet(file.path(parquet_dir, "y=a/part-0.parquet"))
+  partitioned_data <- arrow::read_parquet(
+    file.path(parquet_dir, "y=a/part-0.parquet")
+  )
   testthat::expect_s3_class(partitioned_data, "data.frame")
   testthat::expect_equal(partitioned_data$x, 1)
 
   DBI::dbDisconnect(conn)
 })
 
-testthat::test_that("Error is raised if parquet_path is not provided when save_as_parquet is TRUE", {
+testthat::test_that("If parquet_path provided and save_as_parquet is TRUE", {
   conn <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
 
   # Create a table and insert some data


### PR DESCRIPTION
Modified `R/load_sql_query.R`: Added three new parameters to execute_sql_file():

`save_as_parquet`: Boolean flag to enable saving results to Parquet
`parquet_path`: Path where the Parquet file(s) should be saved
`partition_by`: Optional parameter to partition the output by specified columns

The function now captures the result from `DBI::dbGetQuery()` and conditionally saves it using `arrow::write_dataset()` if `save_as_parquet = TRUE`

Added validation to ensure parquet_path is provided when save_as_parquet is enabled

Added comprehensive tests in `tests/testthat/test_load_sql_query.R`:

- Test for basic Parquet file saving
- Test for partitioned Parquet output
- Test for error handling when parquet_path is missing

**The idea is that we can do all saving as a parquet in one shot when we execute the slq files in complex**

@ioannousolon please review as well