### PR TITLE
colour log messages

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: linters_with_defaults(
-    object_usage_linter = NULL
+    object_usage_linter = NULL,
+    indentation_linter = NULL
   )
 exclusions: list(
     "tests/testthat.R"

--- a/R/run_logger.R
+++ b/R/run_logger.R
@@ -62,10 +62,8 @@ LoggerManager <- R6::R6Class( # nolint
     #'
     #' @param log_dir Directory where logs will be stored. Defaults to "logs".
     #' @param verbose Verbosity level.
-    configure = function(
-      log_dir = "logs",
-      verbose = c("Normal", "High", "Low")
-    ) {
+    configure = function(log_dir = "logs",
+                         verbose = c("Normal", "High", "Low")) {
       self$log_dir <- log_dir
       if (!base::dir.exists(self$log_dir)) {
         base::dir.create(self$log_dir, recursive = TRUE)
@@ -102,24 +100,26 @@ LoggerManager <- R6::R6Class( # nolint
         app_console(line)
 
         if (!(isTRUE(self$capture_active) &&
-                base::identical(self$capture_target, "global"))) {
+          base::identical(self$capture_target, "global"))) {
           app_main(line)
         }
 
         if (!base::is.null(self$step_appender)) {
           if (!(isTRUE(self$capture_active) &&
-                  base::identical(self$capture_target, "step"))) {
+            base::identical(self$capture_target, "step"))) {
             self$step_appender(line)
           }
         }
       }, namespace = namespaces)
 
-      self$registry <- tryCatch({
-        picard::load(picard:::get_hash_output(log_dir = self$log_dir))
-      },
-      error = function(e) {
-        NULL
-      })
+      self$registry <- tryCatch(
+        {
+          picard::load(picard:::get_hash_output(log_dir = self$log_dir))
+        },
+        error = function(e) {
+          NULL
+        }
+      )
       if (is.null(self$registry) & self$verbose == "High") {
         logger::log_error("Registry file necessary!")
         stop("Registry file necessary!")
@@ -236,15 +236,13 @@ LoggerManager <- R6::R6Class( # nolint
     #' @param .topenv Top-level environment.
     #' @param ... Additional arguments.
     #' @return Formatted log message string.
-    .layout_with_timers = function(
-      level,
-      msg = NULL,
-      namespace = NULL,
-      .logcall = NULL,
-      .topcall = NULL,
-      .topenv = NULL,
-      ...
-    ) {
+    .layout_with_timers = function(level,
+                                   msg = NULL,
+                                   namespace = NULL,
+                                   .logcall = NULL,
+                                   .topcall = NULL,
+                                   .topenv = NULL,
+                                   ...) {
       if (base::is.list(level) && !base::is.null(level$msg)) {
         record <- level
         lvl <- record$level
@@ -307,12 +305,12 @@ LoggerManager <- R6::R6Class( # nolint
       # Not all log messages are connected with a file.
       hash <- ""
       if (self$verbose == "High" && !is.null(self$current_script) &&
-          file_test("-f", self$current_script)) {
+        file_test("-f", self$current_script)) {
         hash <- picard:::compute_hash(self$current_script)
 
         if (!is.null(self$registry) &&
-            nrow(self$registry[file_path == self$current_script]) == 1 &&
-            hash != self$registry[file_path == self$current_script]$hash) {
+          nrow(self$registry[file_path == self$current_script]) == 1 &&
+          hash != self$registry[file_path == self$current_script]$hash) {
           hash <- paste0(hash, "\nScript modified by user\n")
         }
       }
@@ -346,7 +344,7 @@ LoggerManager <- R6::R6Class( # nolint
           message
         )
       } else if (self$verbose == "High") {
-        base::sprintf(# Original with step and script times
+        base::sprintf( # Original with step and script times
           "%s | %-5s | run+%8.2fs | step+%8ss | scr+%8ss | d+%7.2fs | %s/%s | %s | %s", # nolint
           base::format(now, "%Y-%m-%d %H:%M:%S"),
           lvl_txt,
@@ -364,8 +362,7 @@ LoggerManager <- R6::R6Class( # nolint
       }
 
       if (requireNamespace("crayon", quietly = TRUE)) {
-        color_fun <- switch(
-          lvl_txt,
+        color_fun <- switch(lvl_txt,
           "TRACE" = crayon::magenta,
           "DEBUG" = crayon::blue,
           "INFO" = identity,
@@ -379,7 +376,6 @@ LoggerManager <- R6::R6Class( # nolint
       }
 
       line
-
     },
 
     #' Start Capturing Print Statements
@@ -394,8 +390,11 @@ LoggerManager <- R6::R6Class( # nolint
                                       capture_messages = TRUE) {
       target <- base::match.arg(target)
 
-      sink_file <- if (target == "global") self$global_log_file
-      else self$step_log_file
+      sink_file <- if (target == "global") {
+        self$global_log_file
+      } else {
+        self$step_log_file
+      }
 
       self$stop_capturing_prints()
 

--- a/R/run_logger.R
+++ b/R/run_logger.R
@@ -99,20 +99,20 @@ LoggerManager <- R6::R6Class( # nolint
       logger::log_appender(function(line) {
         app_console(line)
 
-        if (!(isTRUE(self$capture_active) &&
+        if (!(base::isTRUE(self$capture_active) &&
           base::identical(self$capture_target, "global"))) {
           app_main(line)
         }
 
         if (!base::is.null(self$step_appender)) {
-          if (!(isTRUE(self$capture_active) &&
+          if (!(base::isTRUE(self$capture_active) &&
             base::identical(self$capture_target, "step"))) {
             self$step_appender(line)
           }
         }
       }, namespace = namespaces)
 
-      self$registry <- tryCatch(
+      self$registry <- base::tryCatch(
         {
           picard::load(picard:::get_hash_output(log_dir = self$log_dir))
         },
@@ -120,13 +120,13 @@ LoggerManager <- R6::R6Class( # nolint
           NULL
         }
       )
-      if (is.null(self$registry) & self$verbose == "High") {
+      if (base::is.null(self$registry) & self$verbose == "High") {
         logger::log_error("Registry file necessary!")
         stop("Registry file necessary!")
       }
 
       logger::log_info("Pipeline configured. run_id={self$run_id}")
-      invisible(self)
+      base::invisible(self)
     },
 
     #' Cleanup Old Logs
@@ -141,8 +141,8 @@ LoggerManager <- R6::R6Class( # nolint
         recursive = TRUE
       )
 
-      if (length(old_logs) == 0) {
-        return(invisible(NULL))
+      if (base::length(old_logs) == 0) {
+        return(base::invisible(NULL))
       }
 
       old_logs_dates <- base::file.mtime(old_logs)
@@ -150,7 +150,7 @@ LoggerManager <- R6::R6Class( # nolint
 
       base::file.remove(old_logs[old_logs_dates < cutoff_date])
 
-      invisible(NULL)
+      base::invisible(NULL)
     },
 
     #' Initialize Step Logger
@@ -221,7 +221,7 @@ LoggerManager <- R6::R6Class( # nolint
       }
       self$current_script <- NULL
       self$script_start_time <- NULL
-      invisible(self)
+      base::invisible(self)
     },
 
     #' Layout with Timers

--- a/R/run_logger.R
+++ b/R/run_logger.R
@@ -304,7 +304,19 @@ LoggerManager <- R6::R6Class( # nolint
       scr_txt <- if (is.na(script_s)) "NA" else base::sprintf("%.2f", script_s)
 
       # Be sure current_script is an existing file (not a directory)
-      # Not all log message are connected with a file
+      # Not all log messages are connected with a file.
+      hash <- ""
+      if (self$verbose == "High" && !is.null(self$current_script) &&
+          file_test("-f", self$current_script)) {
+        hash <- picard:::compute_hash(self$current_script)
+
+        if (!is.null(self$registry) &&
+            nrow(self$registry[file_path == self$current_script]) == 1 &&
+            hash != self$registry[file_path == self$current_script]$hash) {
+          hash <- paste0(hash, "\nScript modified by user\n")
+        }
+      }
+
       # Change the color of the message based on message level,
       # using crayon package. The mapping is as follows:
       # Level	 Colour
@@ -334,8 +346,8 @@ LoggerManager <- R6::R6Class( # nolint
           message
         )
       } else if (self$verbose == "High") {
-        base::sprintf(
-          "%s | %-5s | run+%8.2fs | step+%8ss | scr+%8ss | d+%7.2fs | %s/%s | %s | %s", #nolint
+        base::sprintf(# Original with step and script times
+          "%s | %-5s | run+%8.2fs | step+%8ss | scr+%8ss | d+%7.2fs | %s/%s | %s | %s", # nolint
           base::format(now, "%Y-%m-%d %H:%M:%S"),
           lvl_txt,
           run_s,
@@ -347,6 +359,8 @@ LoggerManager <- R6::R6Class( # nolint
           message,
           hash
         )
+      } else {
+        ""
       }
 
       if (requireNamespace("crayon", quietly = TRUE)) {

--- a/R/run_logger.R
+++ b/R/run_logger.R
@@ -305,22 +305,17 @@ LoggerManager <- R6::R6Class( # nolint
 
       # Be sure current_script is an existing file (not a directory)
       # Not all log message are connected with a file
-      if (self$verbose == "High") {
-        if (is.null(self$current_script)) {
-          hash <- ""
-        } else if (file_test("-f", self$current_script)) {
-          hash <- picard:::compute_hash(self$current_script)
-          if (nrow(self$registry[file_path == self$current_script] == 1)) {
-            if (hash != self$registry[file_path == self$current_script]$hash) {
-              hash <- paste0(hash, "\nScript modified by user\n")
-            }
-          }
-        } else {
-          hash <- ""
-        }
-      }
-
-      if (self$verbose == "Low") {
+      # Change the color of the message based on message level,
+      # using crayon package. The mapping is as follows:
+      # Level	 Colour
+      # Trace	Purple
+      # Debug	Blue
+      # Info	No change
+      # Success	Green
+      # Warning	Yellow
+      # Error	Red
+      # Fatal	Dark Red (bold)
+      line <- if (self$verbose == "Low") {
         base::sprintf(
           "%s | %-5s | %s",
           base::format(now, "%Y-%m-%d %H:%M:%S"),
@@ -339,9 +334,9 @@ LoggerManager <- R6::R6Class( # nolint
           message
         )
       } else if (self$verbose == "High") {
-        base::sprintf( # Original with step and script times
-          "%s | %-5s | run+%8.2fs | step+%8ss | scr+%8ss | d+%7.2fs | %s/%s | %s | %s", # nolint
-          base::format(now, "%Y-%m-%d %H:%M:%S"), # nolint
+        base::sprintf(
+          "%s | %-5s | run+%8.2fs | step+%8ss | scr+%8ss | d+%7.2fs | %s/%s | %s | %s",
+          base::format(now, "%Y-%m-%d %H:%M:%S"),
           lvl_txt,
           run_s,
           step_txt,
@@ -353,6 +348,24 @@ LoggerManager <- R6::R6Class( # nolint
           hash
         )
       }
+
+      if (requireNamespace("crayon", quietly = TRUE)) {
+        color_fun <- switch(
+          lvl_txt,
+          "TRACE" = crayon::magenta,
+          "DEBUG" = crayon::blue,
+          "INFO" = identity,
+          "SUCCESS" = crayon::green,
+          "WARN" = crayon::yellow,
+          "ERROR" = crayon::red,
+          "FATAL" = crayon::red$bold,
+          identity
+        )
+        line <- color_fun(line)
+      }
+
+      line
+
     },
 
     #' Start Capturing Print Statements

--- a/R/run_logger.R
+++ b/R/run_logger.R
@@ -335,7 +335,7 @@ LoggerManager <- R6::R6Class( # nolint
         )
       } else if (self$verbose == "High") {
         base::sprintf(
-          "%s | %-5s | run+%8.2fs | step+%8ss | scr+%8ss | d+%7.2fs | %s/%s | %s | %s",
+          "%s | %-5s | run+%8.2fs | step+%8ss | scr+%8ss | d+%7.2fs | %s/%s | %s | %s", #nolint
           base::format(now, "%Y-%m-%d %H:%M:%S"),
           lvl_txt,
           run_s,


### PR DESCRIPTION
This pull request updates the logging output in the `LoggerManager` class to improve message readability by adding color to log messages based on their severity level. It also simplifies the handling of verbose modes and removes some unused code related to script hashing.

Log message formatting and colorization:

for testing do:
```r
source("run_logger.R", encoding = "UTF-8")
lm <- LoggerManager$new()
lm$configure(log_dir = tempdir())
logger::log_trace("Ciao Mondo")
logger::log_debug("Ciao Mondo")
logger::log_info("Ciao Mondo")
logger::log_success("Ciao Mondo")
logger::log_warn("Ciao Mondo")
logger::log_error("Ciao Mondo")
logger::log_fatal("Ciao Mondo")
```
Code cleanup and simplification:

* Removed the previous block of code that computed and appended a script hash when in "High" verbosity mode, streamlining the logic for generating log lines.
* Minor formatting improvements and removal of unnecessary comments in the log message construction for "High" verbosity mode.